### PR TITLE
Changes with the latest setup for SUEP generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The [runSVJ](./test/runSVJ.py) script is a wrapper that can customize and run an
 * `yukawa=[val]`: Yukawa coupling for bifundamental mediator (t channel) (default = 1.0)
 * `temperature=[val]`: temperature for SUEP model (default = 2.0)
 * `decay=[str]`: decay mode for SUEP model (default = generic)
+* `filterHT=[val]`: value of the gen-level HT cut on the SUEP analysis (default = -1.0, no cut)
 * `filterZ2=[bool]`: only keep events with an even number of stable dark hadrons (default = True)
 * `scout=[bool]`: keep scouting collections in miniAOD (default = False)
 * `part=[num]`: part number when producing a sample in multiple jobs (default = 1)

--- a/batch/jobSubmitterSVJ.py
+++ b/batch/jobSubmitterSVJ.py
@@ -174,11 +174,13 @@ class jobSubmitterSVJ(jobSubmitter):
                             "mDark="+str(pdict["mDark"]),
                             "temperature="+str(pdict["temperature"]),
                             "decay="+str(pdict["decay"]),
-                            "scout=1"
                         ]
                         if "filterHT" in pdict:
-                          if pdict["filterHT"] > 0:
-                            arglist.append("filterHT=%1.3f"%pdict["filterHT"]) 
+                            if pdict["filterHT"] > 0:
+                                arglist.append("filterHT=%1.3f"%pdict["filterHT"])
+                        if "scout" in pdict:
+                            arglist.append("scout="+str(pdict["scout"]))
+ 
                     else:
                         arglist = [
                             "channel="+str(pdict["channel"]),

--- a/batch/jobSubmitterSVJ.py
+++ b/batch/jobSubmitterSVJ.py
@@ -174,7 +174,11 @@ class jobSubmitterSVJ(jobSubmitter):
                             "mDark="+str(pdict["mDark"]),
                             "temperature="+str(pdict["temperature"]),
                             "decay="+str(pdict["decay"]),
+                            "scout=1"
                         ]
+                        if "filterHT" in pdict:
+                          if pdict["filterHT"] > 0:
+                            arglist.append("filterHT=%1.3f"%pdict["filterHT"]) 
                     else:
                         arglist = [
                             "channel="+str(pdict["channel"]),

--- a/batch/signals_suep_v0.py
+++ b/batch/signals_suep_v0.py
@@ -3,6 +3,16 @@
 #"cmsRun runSVJ.py suep=1 year=2018 config=step1_GEN outpre=step1 mMediator={} mDark={:.1f} temperature={:.1f} decay='{}' part=1 maxEvents={}".format(med_mass,dark_mes_mass,temp,decay_mode,nevents) 
 
 flist = [
+#filtered, example
+    {
+        "suep": 1,
+        "mMediator": 125,
+        "mDark": 2.0,
+        "temperature": 2.0,
+        "decay": "darkPho",
+        "filterHT": 1000.,
+    },
+
 #baseline
     {
         "suep": 1,

--- a/python/optSVJ.py
+++ b/python/optSVJ.py
@@ -22,6 +22,7 @@ options.register("rinv", 0.3, VarParsing.multiplicity.singleton, VarParsing.varT
 options.register("alpha", "peak", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.register("yukawa", 1.0, VarParsing.multiplicity.singleton, VarParsing.varType.float)
 options.register("temperature", 2.0, VarParsing.multiplicity.singleton, VarParsing.varType.float)
+options.register("filterHT", -1.0, VarParsing.multiplicity.singleton, VarParsing.varType.float)
 options.register("decay", "generic", VarParsing.multiplicity.singleton, VarParsing.varType.string)
 options.register("filterZ2", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool)
 options.register("scout", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool)

--- a/python/suepHelper.py
+++ b/python/suepHelper.py
@@ -22,11 +22,9 @@ class suepHelper(object):
         self.xsec = 1
         self.mMin = self.mMediator-1
         self.mMax = self.mMediator+1
-        self.mPho = self.mDark/2. # dark photon 
-        mPho = self.mDark/2. # generic uubar
-        if   decay == "darkPho"   : mPho = 0.5 # GeV    
-        elif decay == "darkPhoHad": mPho = 0.7 # GeV, allows more pion decays
-        self.mPho = mPho # dark photon mass
+        self.mPho = 1. # full hadronic (previously "generic" is set to 1)
+        if   decay == "darkPho"   : self.mPho = 0.5 # GeV    
+        elif decay == "darkPhoHad": self.mPho = 0.7 # GeV, allows more pion decays
 
     def getOutName(self,events=0,signal=True,outpre="outpre",part=None,sanitize=False):
         _outname = outpre
@@ -64,7 +62,13 @@ class suepHelper(object):
         lines = [
             'Check:event = off',
             # parameters for mediator (Higgs)
-            'HiggsSM:all = on',
+            'Higgs:useBSM = on',
+            'HiggsBSM:gg2H1 = on',
+            'HiggsH1:coup2d = 1',
+            'HiggsH1:coup2u = 0',
+            'HiggsH1:coup2Z = 0',
+            'HiggsH1:coup2W = 0',
+            'HiggsH1:coup2l = 0',
             '{}:m0 = {:g}'.format(self.idMediator,self.mMediator),
             # add a dark meson and dark photon 
             '{}:all = GeneralResonance void 0 0 0 {:g} 0.001 0.0 0.0 0.0'.format(self.idDark,self.mDark),
@@ -83,7 +87,7 @@ class suepHelper(object):
             lines.append('{}:addChannel = 1 0.15 101 13 -13 '.format(self.idPho)  )#15% br to m+ m-
             lines.append('{}:addChannel = 1 0.70 101 211 -211 '.format(self.idPho))#70% br to pi+ pi-
         else : # "generic" uubar
-            lines.append('{}:addChannel = 1 1.0 101 1 -1 '.format(self.idPho)) #100% br to u+ u-
+            lines.append('{}:addChannel = 1 1.0 101 211 -211 '.format(self.idPho)) #100% br to pi+ pi-
 
         return lines
 

--- a/test/runSVJ.py
+++ b/test/runSVJ.py
@@ -81,15 +81,15 @@ if options.signal:
                     _helper.getHookSettings()
                 )
                 if options.filterHT > 0:
-                  process.genHTFilter = cms.EDFilter("GenHTFilter",
-                     src = cms.InputTag("ak4GenJetsNoNu"), #GenJet collection as input
-                     jetPtCut = cms.double(30.0), #GenJet pT cut for HT
-                     jetEtaCut = cms.double(2.5), #GenJet eta cut for HT
-                     genHTcut = cms.double(options.filterHT) #genHT cut
-                  )
-                  if hasattr(process,'ProductionFilterSequence'):
-                    process.ProductionFilterSequence += process.pgen
-                    process.ProductionFilterSequence += process.genHTFilter
+                    process.genHTFilter = cms.EDFilter("GenHTFilter",
+                        src = cms.InputTag("ak4GenJetsNoNu"), #GenJet collection as input
+                        jetPtCut = cms.double(30.0), #GenJet pT cut for HT
+                        jetEtaCut = cms.double(2.5), #GenJet eta cut for HT
+                        genHTcut = cms.double(options.filterHT) #genHT cut
+                    )
+                    if hasattr(process,'ProductionFilterSequence'):
+                        process.ProductionFilterSequence += process.pgen
+                        process.ProductionFilterSequence += process.genHTFilter
     # gen filter settings
     # pythia implementation of model has 4900111/211 -> -51 51 and 4900113/213 -> -53 53
     # this is a stand-in for direct production of a single stable dark meson in the hadronization

--- a/test/runSVJ.py
+++ b/test/runSVJ.py
@@ -81,78 +81,15 @@ if options.signal:
                     _helper.getHookSettings()
                 )
                 if options.filterHT > 0:
-                  process.tmpGenParticles = cms.EDProducer("GenParticleProducer",
-                      saveBarCodes = cms.untracked.bool(True),
-                      src = cms.InputTag("generator","unsmeared"),
-                      abortOnUnknownPDGCode = cms.untracked.bool(False)
-                  )
-
-                  process.tmpGenParticlesForJetsNoNu = cms.EDProducer("InputGenJetsParticleSelector",
-                      src = cms.InputTag("tmpGenParticles"),
-                      ignoreParticleIDs = cms.vuint32(
-                           1000022,
-                           1000012, 1000014, 1000016,
-                           2000012, 2000014, 2000016,
-                           1000039, 5100039,
-                           4000012, 4000014, 4000016,
-                           9900012, 9900014, 9900016,
-                           39,12,14,16),
-                      partonicFinalState = cms.bool(False),
-                      excludeResonances = cms.bool(False),
-                      excludeFromResonancePids = cms.vuint32(12, 13, 14, 16),
-                      tausAsJets = cms.bool(False)
-                  )
-
-                  process.AnomalousCellParameters = cms.PSet(
-                      maxBadEcalCells         = cms.uint32(9999999),
-                      maxRecoveredEcalCells   = cms.uint32(9999999),
-                      maxProblematicEcalCells = cms.uint32(9999999),
-                      maxBadHcalCells         = cms.uint32(9999999),
-                      maxRecoveredHcalCells   = cms.uint32(9999999),
-                      maxProblematicHcalCells = cms.uint32(9999999)
-                  )
-
-                  process.GenJetParameters = cms.PSet(
-                      src            = cms.InputTag("tmpGenParticlesForJetsNoNu"),
-                      srcPVs         = cms.InputTag(''),
-                      jetType        = cms.string('GenJet'),
-                      jetPtMin       = cms.double(3.0),
-                      inputEtMin     = cms.double(0.0),
-                      inputEMin      = cms.double(0.0),
-                      doPVCorrection = cms.bool(False),
-                      # pileup with offset correction
-                      doPUOffsetCorr = cms.bool(False),
-                         # if pileup is false, these are not read:
-                         nSigmaPU = cms.double(1.0),
-                         radiusPU = cms.double(0.5),  
-                      # fastjet-style pileup     
-                      doAreaFastjet  = cms.bool(False),
-                      doRhoFastjet   = cms.bool(False),
-                        # if doPU is false, these are not read:
-                        Active_Area_Repeats = cms.int32(5),
-                        GhostArea = cms.double(0.01),
-                        Ghost_EtaMax = cms.double(6.0),
-                      Rho_EtaMax = cms.double(4.5),
-                      useDeterministicSeed= cms.bool( True ),
-                      minSeed             = cms.uint32( 14327 )
-                  )
-
-                  process.tmpAk4GenJetsNoNu = cms.EDProducer(
-                      "FastjetJetProducer",
-                      process.GenJetParameters,
-                      process.AnomalousCellParameters,
-                      jetAlgorithm = cms.string("AntiKt"),
-                      rParam       = cms.double(0.4)
-                  )
-
                   process.genHTFilter = cms.EDFilter("GenHTFilter",
-                     src = cms.InputTag("tmpAk4GenJetsNoNu"), #GenJet collection as input
+                     src = cms.InputTag("ak4GenJetsNoNu"), #GenJet collection as input
                      jetPtCut = cms.double(30.0), #GenJet pT cut for HT
                      jetEtaCut = cms.double(2.5), #GenJet eta cut for HT
                      genHTcut = cms.double(options.filterHT) #genHT cut
                   )
                   if hasattr(process,'ProductionFilterSequence'):
-                    process.ProductionFilterSequence += process.tmpGenParticles * process.tmpGenParticlesForJetsNoNu * process.tmpAk4GenJetsNoNu * process.genHTFilter
+                    process.ProductionFilterSequence += process.pgen
+                    process.ProductionFilterSequence += process.genHTFilter
     # gen filter settings
     # pythia implementation of model has 4900111/211 -> -51 51 and 4900113/213 -> -53 53
     # this is a stand-in for direct production of a single stable dark meson in the hadronization


### PR DESCRIPTION
Several minor bugfixes going on on this one:
- gg->SM H production replaced by gg-> BSM H, with H coupling only to down type quarks. I.e., without changing kinematics force the scalar resonance to be narrow (as in an effective dim 5 GGH coupling).
- "Generic" decay (i.e. full hadronic) changed so it has fixed mA'=1 GeV.
- Added the genHT filter option as tested for SUEP production.