### PR TITLE
LHE fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The [runSVJ](./test/runSVJ.py) script is a wrapper that can customize and run an
 * `fragment=[string]`: name of file w/ `processParameters` fragment
 * `madgraph=[bool]`: generation with MadGraph (instead of default Pythia8)
 * `nogridpack=[bool]`: disable gridpack mode and just generate events (only for `runMG`) (default = False)
-* `syst=[bool]`: enable systematics for generation with MadGraph (default = False)
+* `syst=[bool]`: enable systematics for generation with MadGraph (used in LHE step) (default = False)
 * `suep=[bool]`: run SUEP simulation (default = False)
 * `channel=[string]`: process to generate (default = s, alternative = t)
 * `boost=[float]`: applies a minimum cut of this value (default = 0.0)

--- a/test/runMG.py
+++ b/test/runMG.py
@@ -47,9 +47,8 @@ set -e
 cd {0}
 ln -sf {1} .
 eval `scram unsetenv -sh`
-export DO_MG_SYSTEMATICS={6}
-export GRIDPACK_NEVENTS={7}
-export NO_GRIDPACK={8}
+export GRIDPACK_NEVENTS={6}
+export NO_GRIDPACK={7}
 ./gridpack_generation.sh {2} {3}
 mv {2}_*.tar.xz {4}
 cd {4}
@@ -61,7 +60,6 @@ cd {4}
     os.path.basename(mg_input_dir),
     os.getcwd(),
     "echo" if options.dump else "rm -rf", # use options.dump to keep gridpack dir
-    "true" if options.syst else "",
     options.maxEvents,
     "true" if options.nogridpack else "",
 )

--- a/test/runSVJ.py
+++ b/test/runSVJ.py
@@ -40,6 +40,7 @@ if len(_inname)>0:
             _inname = _inname.split('/')[-1]
         process.externalLHEProducer.args = cms.vstring(os.path.join(os.getcwd(),_inname))
         process.externalLHEProducer.nEvents = cms.untracked.uint32(options.maxEvents)
+        if options.syst: process.externalLHEProducer.scriptName = cms.FileInPath("SVJ/Production/test/run_svj_tarball_syst.sh")
 if process.source.type_()=='EmptySource':
     process.source.firstEvent = cms.untracked.uint32((options.part-1)*options.maxEvents+1)
     if len(options.scan)>0: process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(100)

--- a/test/runSVJ.py
+++ b/test/runSVJ.py
@@ -34,11 +34,7 @@ if len(_inname)>0:
     elif hasattr(process,"externalLHEProducer"):
         _inname = _helper.getOutName(events=options.maxEventsIn,outpre=options.inpre,gridpack=True)+".tar.xz"
         _inname = fix_inname(_inname,options,True)
-        # fetch the gridpack file from xrootd
-        if _inname.startswith("root:"):
-            os.system("xrdcp -f "+_inname+" .")
-            _inname = _inname.split('/')[-1]
-        process.externalLHEProducer.args = cms.vstring(os.path.join(os.getcwd(),_inname))
+        process.externalLHEProducer.args = cms.vstring(_inname)
         process.externalLHEProducer.nEvents = cms.untracked.uint32(options.maxEvents)
         if options.syst: process.externalLHEProducer.scriptName = cms.FileInPath("SVJ/Production/test/run_svj_tarball_syst.sh")
 if process.source.type_()=='EmptySource':

--- a/test/run_svj_tarball.sh
+++ b/test/run_svj_tarball.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+# fetch the gridpack file from xrootd
+in_path=${1}
+if [[ "$in_path" == "root://"* ]]; then
+	xrdcp -f $in_path .
+	# reset arg to be passed to CMSSW script below
+	set -- "$PWD/$(basename $in_path)" "${@:2}"
+fi
+
 $CMSSW_RELEASE_BASE/src/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh "$@"
 
 # convert madgraph ids to pythia ids

--- a/test/run_svj_tarball_syst.sh
+++ b/test/run_svj_tarball_syst.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+export DO_MG_SYSTEMATICS=true
+COMMAND_NAME=$(echo $0 | sed 's/_syst.sh/.sh/')
+$COMMAND_NAME "$@"


### PR DESCRIPTION
* systematics need to be enabled in the LHE step, not the GRIDPACK step
* the previous method of xrdcp'ing the gridpack in the python config caused the output files to have spurious provenance differences (because the path in `externalLHEProducer.args` would change for each job). now, the xrdcp is done in the run script, which is executed after the python config, so the provenance shows the original (xrootd) path.