### PR TITLE
Added channel option and Z' channel to EMJ

### DIFF
--- a/batch/jobSubmitterSVJ.py
+++ b/batch/jobSubmitterSVJ.py
@@ -149,7 +149,7 @@ class jobSubmitterSVJ(jobSubmitter):
                 elif self.model=="suep":
                     self.helper.setModel(pdict["channel"],pdict["mMediator"],pdict["mDark"],pdict["temperature"],pdict["decay"])
                 elif self.model=="emj":
-                    self.helper.setModel(pdict["mMediator"],pdict["mDark"],pdict["kappa"],pdict["mode"],pdict["type"])
+                    self.helper.setModel(pdict["mMediator"],pdict["mDark"],pdict["kappa"],pdict["mode"],pdict["type"],pdict["channel"])
                 outpre = self.outpre
                 inpre = self.inpre
                 signal = True
@@ -209,6 +209,7 @@ class jobSubmitterSVJ(jobSubmitter):
                     elif self.model=="emj":
                         arglist = [
                             "model=emj",
+                            "channel="+str(pdict["channel"]),
                             "mMediator="+str(pdict["mMediator"]),
                             "mDark="+str(pdict["mDark"]),
                             "kappa="+str(pdict["kappa"]),

--- a/batch/jobSubmitterSVJ.py
+++ b/batch/jobSubmitterSVJ.py
@@ -149,7 +149,7 @@ class jobSubmitterSVJ(jobSubmitter):
                 elif self.model=="suep":
                     self.helper.setModel(pdict["channel"],pdict["mMediator"],pdict["mDark"],pdict["temperature"],pdict["decay"])
                 elif self.model=="emj":
-                    self.helper.setModel(pdict["mMediator"],pdict["mDark"],pdict["kappa"],pdict["mode"],pdict["type"],pdict["channel"])
+                    self.helper.setModel(pdict["channel"],pdict["mMediator"],pdict["mDark"],pdict["kappa"],pdict["mode"],pdict["type"])
                 outpre = self.outpre
                 inpre = self.inpre
                 signal = True

--- a/batch/signals_emj_z.py
+++ b/batch/signals_emj_z.py
@@ -1,0 +1,10 @@
+flist = [
+    {
+        "channel": "s", 
+        "mMediator": 1000, 
+        "mDark": 20, 
+        "kappa": 1, 
+        "mode": "unflavored", 
+        "type": "down"
+    },
+]

--- a/batch/signals_emj_ztest.py
+++ b/batch/signals_emj_ztest.py
@@ -1,0 +1,3 @@
+flist = [
+    {"mMediator": 1000, "mDark": 20, "kappa": 1, "mode": "unflavored", "type": "down", "channel": "s"},
+]

--- a/python/emjHelper.py
+++ b/python/emjHelper.py
@@ -15,13 +15,14 @@ class emjHelper(object):
         self.kap2 = 0
         self.BuildMatrix()
 
-    def setModel(self, mMed, mDark, kappa, mode='aligned', type="down"):
+    def setModel(self, mMed, mDark, kappa, mode='aligned', type="down", channel="t"):
         self.mMed = mMed
         self.mDark = mDark
-        self.kappa0 = kappa
+        self.kappa0 = kappa 
         self.mode = mode
         self.type = type
-        self.xsec = self.xsecs(self.mMed)*3 # number of colors
+        self.xsec = self.xsecs(self.mMed)*3
+        self.channel = channel
 
         # Checking the alignment mode
         if self.mode == 'aligned':
@@ -74,7 +75,9 @@ class emjHelper(object):
 
     def getOutName(self, signal=True, events=0, outpre='outpre', part=None, sanitize=False, gridpack=False):
         _outname = outpre
+
         if signal:
+            _outname += '_{}-channel'.format(self.channel)
             _outname += '_mMed-{:g}'.format(self.mMed)
             _outname += '_mDark-{:g}'.format(self.mDark)
             _outname += '_{}-{:g}'.format(
@@ -126,22 +129,37 @@ class emjHelper(object):
             'ParticleDecays:xyMax = 30000',    # in mm/c
             'ParticleDecays:zMax = 30000',    # in mm/c
             'ParticleDecays:limitCylinder = on',    # yes
-            'HiddenValley:gg2DvDvbar = on',    # gg fusion
-            'HiddenValley:qqbar2DvDvbar = on',    # qqbar annihilation
-            'HiddenValley:alphaOrder = 1',    # Let it run
-            'HiddenValley:Ngauge = 3',    # Number of dark QCD colors
-            'HiddenValley:FSR = on',
-            'HiddenValley:fragment = on',
-            # flavors used for the running
-            'HiddenValley:nFlav = {nflv}'.format(nflv = 7 if self.mode == 'unflavored' else 3),
-            # implements arXiv:1803.08080
-            'HiddenValley:altHadronSpecies = {flag}'.format(flag = 'off' if self.mode == 'unflavored' else 'on'),
-            'HiddenValley:spinFv = 0',    # Spin of bi-fundamental res.
-            'HiddenValley:Lambda = {0}'.format(2 * self.mDark),
-            'HiddenValley:pTminFSR = {ptmin}'.format(ptmin=2.2 * self.mDark),
-            '4900101:m0 = {mass}'.format(mass=2 * self.mDark),
         ]
 
+        if self.channel == "t":
+            t_process = [
+                'HiddenValley:gg2DvDvbar = on',    # gg fusion
+                'HiddenValley:qqbar2DvDvbar = on',    # qqbar annihilation
+            ]
+            lines.extend(t_process)
+        elif self.channel == "s":
+            s_process = [
+                'HiddenValley:ffbar2Zv = on'
+            ]
+            lines.extend(s_process)
+
+        lines.extend(
+            [
+                'HiddenValley:alphaOrder = 1',    # Let it run
+                'HiddenValley:Ngauge = 3',    # Number of dark QCD colors
+                'HiddenValley:FSR = on',
+                'HiddenValley:fragment = on',
+                # flavors used for the running
+                'HiddenValley:nFlav = {nflv}'.format(nflv = 7 if self.mode == 'unflavored' else 3),
+                # implements arXiv:1803.08080
+                'HiddenValley:altHadronSpecies = {flag}'.format(flag = 'off' if self.mode == 'unflavored' else 'on'),
+                'HiddenValley:spinFv = 0',    # Spin of bi-fundamental res.
+                'HiddenValley:Lambda = {0}'.format(2 * self.mDark),
+                'HiddenValley:pTminFSR = {ptmin}'.format(ptmin=2.2 * self.mDark),
+                '4900101:m0 = {mass}'.format(mass=2 * self.mDark),
+            ]
+        )
+    
         lines.extend(self.MakeRes())
         lines.extend(self.MakeDecay())
         return lines
@@ -206,26 +224,47 @@ class emjHelper(object):
                     for j in range(i, 3)
                 ])
             return ans
+        
+        decay_settings = []
 
         if self.mode == 'unflavored':    # Special case for unflavored decay
             smid = 1 if self.type == 'down' else 2
-            return [
-                '4900111:m0 = {mass}'.format(mass=self.mDark),
-                '4900211:m0 = {mass}'.format(mass=self.mDark),
-                '4900111:tau0 = {lifetime}'.format(lifetime=self.kappa0),
-                '4900211:tau0 = {lifetime}'.format(lifetime=self.kappa0),
-                '4900113:m0 = {mass}'.format(mass=4 * self.mDark),
-                '4900213:m0 = {mass}'.format(mass=4 * self.mDark),
-                '4900111:0:all      =  1 1.000  91     {id}     -{id}'.format(id=smid),
-                '4900113:0:all      =  1 0.999  91  4900111   4900111',
-                '4900113:addchannel =  1 0.001  91     {id}     -{id}'.format(id=smid),
-                '4900211:oneChannel =  1 1.000  91     {id}     -{id}'.format(id=smid),
-                '4900213:oneChannel =  1 0.999  91  4900211   4900211',
-                '4900213:addchannel =  1 0.001  91     {id}     -{id}'.format(id=smid),
-            ]
+            decay_settings.extend(
+                [
+                    '4900111:m0 = {mass}'.format(mass=self.mDark),
+                    '4900211:m0 = {mass}'.format(mass=self.mDark),
+                    '4900111:tau0 = {lifetime}'.format(lifetime=self.kappa0),
+                    '4900211:tau0 = {lifetime}'.format(lifetime=self.kappa0),
+                    '4900113:m0 = {mass}'.format(mass=4 * self.mDark),
+                    '4900213:m0 = {mass}'.format(mass=4 * self.mDark),
+                    '4900111:0:all      =  1 1.000  91     {id}     -{id}'.format(id=smid),
+                    '4900113:0:all      =  1 0.999  91  4900111   4900111',
+                    '4900113:addchannel =  1 0.001  91     {id}     -{id}'.format(id=smid),
+                    '4900211:oneChannel =  1 1.000  91     {id}     -{id}'.format(id=smid),
+                    '4900213:oneChannel =  1 0.999  91  4900211   4900211',
+                    '4900213:addchannel =  1 0.001  91     {id}     -{id}'.format(id=smid),
+                ]
+            )
+            if self.channel == "s":
+                zprime_decay = [
+                    '4900023:m0 = {mMed}'.format(mMed=self.mMed),
+                    '4900023:mWidth = 0.01',  # Width of the Z' boson
+                    '4900023:oneChannel = 1 0.982 102 4900101 -4900101',
+                    '4900023:addChannel = 1 0.003 102 1 -1', 
+                    '4900023:addChannel = 1 0.003 102 2 -2',
+                    '4900023:addChannel = 1 0.003 102 3 -3',
+                    '4900023:addChannel = 1 0.003 102 4 -4',
+                    '4900023:addChannel = 1 0.003 102 5 -5',
+                    '4900023:addChannel = 1 0.003 102 6 -6',
+                ]
+                decay_settings.extend(zprime_decay)
+            return decay_settings
         elif self.mode == 'aligned':
             # PDG ID should match with hidden valley definition
             # https://github.com/cms-svj/pythia8/tree/emj/306
+
+            if self.channel == "s":
+                raise ValueError("Option for mode {} not compatible with channel option {}".format(self.mode, self.channel))
 
             # Defining some missing antiparticles
             meson_decay = [
@@ -256,7 +295,11 @@ if __name__ == "__main__":
     parser.add_argument('--mDark', default=10, type=float, help='Dark meson mass [GeV]')
     parser.add_argument('--type', default='down', type=str, choices=['down', 'up'], help='Alignment to SM up/down type SM quarks')
     parser.add_argument('--mode', default='aligned', type=str, choices=['aligned', 'unflavored'], help='Mixing scenarios to simulate')
+    # Z'
+    parser.add_argument('--channel', default='t', type=str, choices=['t', 's'], help='Channels to simulate')
+    ##
     parser.add_argument('cmd', type=str, choices=['dumptime','dumpcard'], help='action to perform')
+    # New
 
     args = parser.parse_args()
 
@@ -277,7 +320,7 @@ if __name__ == "__main__":
 
             print('{:10g} {:16g} {:16g} {:16g} {:16g}'.format(mDark, get_time(4900111), get_time(4900113), get_time(4900211), get_time(4900213)))
     elif args.cmd == 'dumpcard':
-        helper.setModel(args.mMed, args.mDark, args.kappa, args.mode, args.type)
+        helper.setModel(args.mMed, args.mDark, args.kappa, args.mode, args.type, args.channel)
         for line in helper.getPythiaSettings():
             print(line)
 

--- a/python/optSVJ.py
+++ b/python/optSVJ.py
@@ -95,7 +95,7 @@ elif options.model=="suep":
     options.filterZ2 = False
 elif options.model=="emj":
     _helper = emjHelper()
-    _helper.setModel(options.mMediator,options.mDark,options.kappa,options.mode,options.type,options.channel)
+    _helper.setModel(options.channel,options.mMediator,options.mDark,options.kappa,options.mode,options.type)
     options.filterZ2 = False
 else:
     raise ValueError("Unknown model {}".format(options.model))

--- a/python/optSVJ.py
+++ b/python/optSVJ.py
@@ -95,8 +95,7 @@ elif options.model=="suep":
     options.filterZ2 = False
 elif options.model=="emj":
     _helper = emjHelper()
-    _helper.setModel(options.mMediator,options.mDark,options.kappa,options.mode,options.type)
+    _helper.setModel(options.mMediator,options.mDark,options.kappa,options.mode,options.type,options.channel)
     options.filterZ2 = False
-    options.channel = ""
 else:
     raise ValueError("Unknown model {}".format(options.model))


### PR DESCRIPTION
This PR enables the production of s-channel EMJ samples using Pythia. A new `channel` option allows for the selection between t-channel and s-channel production of EMJ samples.